### PR TITLE
Add Chinese translation for chat and in game multiplayer menu when encoding is Big5 or CP936.

### DIFF
--- a/src/chat_multiplayer.cpp
+++ b/src/chat_multiplayer.cpp
@@ -13,6 +13,7 @@
 #include "cache.h"
 #include "input.h"
 #include "utils.h"
+#include "player.h"
 #include "compiler.h"
 #include "game_multiplayer_my_data.h"
 
@@ -179,14 +180,25 @@ namespace {
 		void refreshTheme() { }
 
 		void setConnectionStatus(bool status) {
-			std::string connLabel = (status)?"Connected":"Disconnected";
+			std::string connLabel = "";
+			if (Player::IsCP936()) {
+				connLabel = (status)?"已连接":"未连接";
+			} else {
+				connLabel = (status)?"Connected":"Disconnected";
+			}
+				
 			auto cRect = Font::Default()->GetSize(connLabel);
 			connStatus = Bitmap::Create(cRect.width+1, cRect.height+1, true);
 			Text::Draw(*connStatus, 0, 0, *Font::Default(), *Cache::SystemOrBlack(), 2, connLabel);
 		}
 
 		void setRoomStatus(unsigned int roomID) {
-			std::string roomLabel = "Room #"+std::to_string(roomID);
+			std::string roomLabel = "";
+			if (Player::IsCP936()) {
+				roomLabel = "房间 #"+std::to_string(roomID);
+			} else {
+				roomLabel = "Room #"+std::to_string(roomID);
+			}
 			auto rRect = Font::Default()->GetSize(roomLabel);
 			roomStatus = Bitmap::Create(rRect.width+1, rRect.height+1, true);
 			Text::Draw(*roomStatus, 0, 0, *Font::Default(), *Cache::SystemOrBlack(), 2, roomLabel);
@@ -691,8 +703,11 @@ namespace {
 
 	void initialize() {
 		chatBox = std::make_unique<DrawableChat>();
-
-		chatBox->showTypeLabel("Name");
+		if (Player::IsCP936()) {
+			chatBox->showTypeLabel("昵称");
+		} else {
+			chatBox->showTypeLabel("Name");
+		}
 
 		// load saved user profile preferences from JS side (name)
 		char* configNameStr = (char*)EM_ASM_INT({
@@ -718,25 +733,63 @@ namespace {
 		preloadTrip = Utils::DecodeUTF32(cfgTripStr);
 		free(configTripStr);
 
-		addLogEntry("", "!! • IME input now supported!", "", CV_LOCAL);
-		addLogEntry("", "!!   (for Japanese, etc.)", "", CV_LOCAL);
-		addLogEntry("", "!! • You can now copy and", "", CV_LOCAL);
-		addLogEntry("", "!!   paste from type box.", "", CV_LOCAL);
-		addLogEntry("", "!! • SHIFT+[←, →] to select text.", "", CV_LOCAL);
-		addLogEntry("", "", "―――", CV_LOCAL);
+		if (Player::IsCP936()) {
+			addLogEntry("", "!! • 输入法现已支持！", "", CV_LOCAL);
+			addLogEntry("", "!! • 你可以在输入框", "", CV_LOCAL);
+			addLogEntry("", "!!   复制和粘贴了。", "", CV_LOCAL);
+			addLogEntry("", "!! • 使用 SHIFT+[←, →] 选中文本。", "", CV_LOCAL);
+			addLogEntry("", "", "―――", CV_LOCAL);
 
-		addLogEntry("[TAB]: ", "focus/unfocus.", "", CV_LOCAL);
-		addLogEntry("[↑, ↓]: ", "scroll.", "", CV_LOCAL);
-		addLogEntry("[F8]: ", "hide/show global chat.", "", CV_LOCAL);
-		addLogEntry("", "", "―――", CV_LOCAL);
-		addLogEntry("• Type /help to list commands.", "", "", CV_LOCAL);
-		addLogEntry("• Use '!' at the bebining of", "", "", CV_LOCAL);
-		addLogEntry("  message for global chat.", "", "", CV_LOCAL);
-		addLogEntry("", "", "―――", CV_LOCAL);
-		addLogEntry("• Set a nickname", "", "", CV_LOCAL);
-		addLogEntry("  for chat.", "", "", CV_LOCAL);
-		addLogEntry("• Max 8 characters.", "", "", CV_LOCAL);
-		addLogEntry("• Alphanumeric only.", "", "", CV_LOCAL);
+			addLogEntry("[TAB]: ", "打开/关闭对话模式。", "", CV_LOCAL);
+			addLogEntry("[↑, ↓]: ", "滚动聊天框", "", CV_LOCAL);
+			addLogEntry("[F8]: ", "隐藏/显示全局聊天框。", "", CV_LOCAL);
+			addLogEntry("", "", "―――", CV_LOCAL);
+			addLogEntry("• 输入 /help 获取指令列表。", "", "", CV_LOCAL);
+			addLogEntry("• 在消息开头输入 '!' ", "", "", CV_LOCAL);
+			addLogEntry("  来发送全局消息。", "", "", CV_LOCAL);
+			addLogEntry("", "", "―――", CV_LOCAL);
+			addLogEntry("• 选择一个昵称", "", "", CV_LOCAL);
+			addLogEntry("• 最多 8 个字符。", "", "", CV_LOCAL);
+			addLogEntry("• 仅允许字母与数字。", "", "", CV_LOCAL);
+		} else if (Player::IsBig5()) {
+			addLogEntry("", "!! • 輸入法現已支持！", "", CV_LOCAL);
+			addLogEntry("", "!! • 你可以在輸入框", "", CV_LOCAL);
+			addLogEntry("", "!!   復製和粘貼了。", "", CV_LOCAL);
+			addLogEntry("", "!! • 使用 SHIFT+[←, →] 選中文本。", "", CV_LOCAL);
+			addLogEntry("", "", "―――", CV_LOCAL);
+
+			addLogEntry("[TAB]: ", "打開/關閉對話模式。", "", CV_LOCAL);
+			addLogEntry("[↑, ↓]: ", "滾動聊天框", "", CV_LOCAL);
+			addLogEntry("[F8]: ", "隱藏/顯示全局聊天框。", "", CV_LOCAL);
+			addLogEntry("", "", "―――", CV_LOCAL);
+			addLogEntry("• 輸入 /help 獲取指令列表。", "", "", CV_LOCAL);
+			addLogEntry("• 在消息開頭輸入 '!' ", "", "", CV_LOCAL);
+			addLogEntry("  來發送全局消息。", "", "", CV_LOCAL);
+			addLogEntry("", "", "―――", CV_LOCAL);
+			addLogEntry("• 選擇一個昵稱", "", "", CV_LOCAL);
+			addLogEntry("• 最多 8 個字符。", "", "", CV_LOCAL);
+			addLogEntry("• 僅允許字母與數字。", "", "", CV_LOCAL);
+		} else {
+			addLogEntry("", "!! • IME input now supported!", "", CV_LOCAL);
+			addLogEntry("", "!!   (for Japanese, etc.)", "", CV_LOCAL);
+			addLogEntry("", "!! • You can now copy and", "", CV_LOCAL);
+			addLogEntry("", "!!   paste from type box.", "", CV_LOCAL);
+			addLogEntry("", "!! • SHIFT+[←, →] to select text.", "", CV_LOCAL);
+			addLogEntry("", "", "―――", CV_LOCAL);
+
+			addLogEntry("[TAB]: ", "focus/unfocus.", "", CV_LOCAL);
+			addLogEntry("[↑, ↓]: ", "scroll.", "", CV_LOCAL);
+			addLogEntry("[F8]: ", "hide/show global chat.", "", CV_LOCAL);
+			addLogEntry("", "", "―――", CV_LOCAL);
+			addLogEntry("• Type /help to list commands.", "", "", CV_LOCAL);
+			addLogEntry("• Use '!' at the begining of", "", "", CV_LOCAL);
+			addLogEntry("  message for global chat.", "", "", CV_LOCAL);
+			addLogEntry("", "", "―――", CV_LOCAL);
+			addLogEntry("• Set a nickname", "", "", CV_LOCAL);
+			addLogEntry("  for chat.", "", "", CV_LOCAL);
+			addLogEntry("• Max 8 characters.", "", "", CV_LOCAL);
+			addLogEntry("• Alphanumeric only.", "", "", CV_LOCAL);
+		}
 	}
 
 	void setFocus(bool focused) {

--- a/src/font.cpp
+++ b/src/font.cpp
@@ -71,11 +71,23 @@ namespace {
 	}
 
 	BitmapFontGlyph const* find_gothic_glyph(char32_t code) {
+		if (Player::IsCP936()) {
+			auto* wqy = find_glyph(BITMAPFONT_WQY, code);
+			if (wqy != NULL) {
+				return wqy;
+			}
+		}
 		auto* gothic = find_glyph(SHINONOME_GOTHIC, code);
 		return gothic != NULL ? gothic : find_fallback_glyph(code);
 	}
 
 	BitmapFontGlyph const* find_mincho_glyph(char32_t code) {
+		if (Player::IsCP936()) {
+			auto* wqy = find_glyph(BITMAPFONT_WQY, code);
+			if (wqy != NULL) {
+				return wqy;
+			}
+		}		
 		auto* mincho = find_glyph(SHINONOME_MINCHO, code);
 		return mincho == NULL ? find_gothic_glyph(code) : mincho;
 	}

--- a/src/game_multiplayer_settings_scene.cpp
+++ b/src/game_multiplayer_settings_scene.cpp
@@ -8,6 +8,7 @@
 #include "bitmap.h"
 #include "output.h"
 #include "font.h"
+#include "player.h"
 #include <algorithm>
 #include <cmath>
 #include <math.h>
@@ -38,14 +39,36 @@ namespace Game_Multiplayer {
 				win.SetText("");
 			}
 		};
-		items.push_back(std::make_unique<SwitchOption>("SFX sync", "Lets you hear sound effects that other players produce", &MyData::sfxsync));
-		items.push_back(std::make_unique<RangeOption>("SFX falloff", "Maximum distance at which you can hear players", &MyData::sfxfalloff, 4, 32, 1));
-		items.push_back(std::make_unique<RangeOption>("Players SFX volume", "Volume of the sound effects that other players produce", &MyData::playersVolume, 0, 100, 2));
-		items.push_back(std::make_unique<SwitchOption>("NPC synchironisation", "Lets you and other players see NPC at same positions", &MyData::syncnpc));
-		items.push_back(std::make_unique<SwitchOption>("Nametags", "Lets you see usernames of the players in game", &MyData::rendernametags));
-		items.push_back(std::make_unique<SwitchOption>("Nametags system sync", "Render nametags with system colors that player is using", &MyData::systemsync));
-		items.push_back(std::make_unique<ActionOption>("Global chat", "Toggle global chat visibility", &ToggleGlobalChatVisivility));
-		items.push_back(std::make_unique<ActionOption>("Reconnect", "Disconnect, clear players & connect again", &Reconnect));
+
+		if (Player::IsCP936()) {
+			items.push_back(std::make_unique<SwitchOption>("音效同步", "可以听见其他玩家的音效", &MyData::sfxsync));
+			items.push_back(std::make_unique<RangeOption>("音效距离", "可以听见其他玩家的音效的最大距离", &MyData::sfxfalloff, 4, 32, 1));
+			items.push_back(std::make_unique<RangeOption>("音效音量", "其他玩家产生音效的音量", &MyData::playersVolume, 0, 100, 2));
+			items.push_back(std::make_unique<SwitchOption>("NPC 同步", "你和其他玩家看见的 NPC 的位置相同", &MyData::syncnpc));
+			items.push_back(std::make_unique<SwitchOption>("显示昵称", "可以看见玩家们的昵称", &MyData::rendernametags));
+			items.push_back(std::make_unique<SwitchOption>("多彩名片", "将玩家的昵称染上其正在使用的系统颜色", &MyData::systemsync));
+			items.push_back(std::make_unique<ActionOption>("全局聊天", "是否开启全局聊天", &ToggleGlobalChatVisivility));
+			items.push_back(std::make_unique<ActionOption>("断线重连", "断开连接，清除玩家并重新连接", &Reconnect));
+		} else if (Player::IsBig5()) {
+			items.push_back(std::make_unique<SwitchOption>("音效同步", "可以聽見其他玩家的音效", &MyData::sfxsync));
+			items.push_back(std::make_unique<RangeOption>("音效距離", "可以聽見其他玩家的音效的最大距離", &MyData::sfxfalloff, 4, 32, 1));
+			items.push_back(std::make_unique<RangeOption>("音效音量", "其他玩家產生音效的音量", &MyData::playersVolume, 0, 100, 2));
+			items.push_back(std::make_unique<SwitchOption>("NPC 同步", "你和其他玩家看見的 NPC 的位置相同", &MyData::syncnpc));
+			items.push_back(std::make_unique<SwitchOption>("顯示昵稱", "可以看見玩家們的昵稱", &MyData::rendernametags));
+			items.push_back(std::make_unique<SwitchOption>("多彩名片", "將玩家的昵稱染上其正在使用的系統顏色", &MyData::systemsync));
+			items.push_back(std::make_unique<ActionOption>("全局聊天", "是否開啟全局聊天", &ToggleGlobalChatVisivility));
+			items.push_back(std::make_unique<ActionOption>("斷線重連", "斷開連接，清除玩家並重新連接", &Reconnect));
+		} else {
+			items.push_back(std::make_unique<SwitchOption>("SFX sync", "Lets you hear sound effects that other players produce", &MyData::sfxsync));
+			items.push_back(std::make_unique<RangeOption>("SFX falloff", "Maximum distance at which you can hear players", &MyData::sfxfalloff, 4, 32, 1));
+			items.push_back(std::make_unique<RangeOption>("Players SFX volume", "Volume of the sound effects that other players produce", &MyData::playersVolume, 0, 100, 2));
+			items.push_back(std::make_unique<SwitchOption>("NPC synchronisation", "Lets you and other players see NPC at same positions", &MyData::syncnpc));
+			items.push_back(std::make_unique<SwitchOption>("Nametags", "Lets you see usernames of the players in game", &MyData::rendernametags));
+			items.push_back(std::make_unique<SwitchOption>("Nametags system sync", "Render nametags with system colors that player is using", &MyData::systemsync));
+			items.push_back(std::make_unique<ActionOption>("Global chat", "Toggle global chat visibility", &ToggleGlobalChatVisivility));
+			items.push_back(std::make_unique<ActionOption>("Reconnect", "Disconnect, clear players & connect again", &Reconnect));
+		}
+
 		this->item_max = items.size();
 		CreateContents();
 		SetEndlessScrolling(false);

--- a/src/scene_menu.cpp
+++ b/src/scene_menu.cpp
@@ -127,7 +127,7 @@ void Scene_Menu::CreateCommandWindow() {
 			options.push_back("Debug");
 			break;
 		case Multiplayer:
-			options.push_back("Multiplayer");
+			options.push_back(Player::IsCP936() ? "通信设置" : (Player::IsBig5() ? "通信設置" : "Multiplayer"));
 			break;
 		default:
 			options.push_back(ToString(lcf::Data::terms.menu_quit));


### PR DESCRIPTION

![MREGTXC%2)Y$@ R5PTCJ6_H](https://user-images.githubusercontent.com/2507027/154496845-7de17f87-c427-4796-a7da-35dbe963c6fe.png)

![V($Z2SL~}LTWN0M0 Z3Z`MN](https://user-images.githubusercontent.com/2507027/154496820-ab135618-4358-49de-9af6-d9cf61d0ac20.png)

Also [merged this pr from upstream](https://github.com/EasyRPG/Player/pull/2725).
